### PR TITLE
Allow setting API version

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -77,3 +77,12 @@ type QueryResponse struct {
 	// Result is the raw JSON of the query result.
 	Result *json.RawMessage `json:"result"`
 }
+
+// GetDocumentsResponse holds result of GET documents API call.
+type GetDocumentsResponse struct {
+	// Documents is slice of documents
+	Documents []Document `json:"documents"`
+}
+
+// Document is a map of document attributes
+type Document map[string]interface{}

--- a/api/types.go
+++ b/api/types.go
@@ -9,7 +9,8 @@ type MutateRequest struct {
 }
 
 type MutateResponse struct {
-	Results []*MutateResultItem `json:"results"`
+	TransactionID string              `json:"transactionId"`
+	Results       []*MutateResultItem `json:"results"`
 }
 
 type MutationItem struct {

--- a/client.go
+++ b/client.go
@@ -229,3 +229,5 @@ func (c *Client) newQueryRequest() *requests.Request {
 	c.setHeaders(r)
 	return r
 }
+
+const maxGETRequestURLLength = 1024

--- a/client.go
+++ b/client.go
@@ -27,14 +27,18 @@ const (
 	// API Host which connects through CDN
 	APICDNHost = "apicdn.sanity.io"
 
-	// VersionV1 is version 1, the initial released version
+	// VersionV1 is API version 1, the initial released version
 	VersionV1 = Version("1")
 
-	// VersionExperimental is the experimental version
+	// VersionExperimental is the experimental API version
 	VersionExperimental = Version("X")
 
-	// Latest release
+	// Latest API version release
 	VersionV20210325 = Version("2021-03-25")
+
+	// Deprecated: VersionDefault is the API version used when client is
+	// instantiated without any specific version.
+	VersionDefault = VersionV1
 )
 
 // Version is an API version, generally be dates in ISO format but also
@@ -127,6 +131,16 @@ func WithHTTPHeader(key, value string) Option {
 		}
 		c.customHeaders.Add(key, value)
 	}
+}
+
+// Deprecated: Use version.NewClient() instead.
+// New returns a new client with a default API version. A project ID must be provided.
+// Zero or more options can be passed. For example:
+//
+//     client := sanity.New("projectId", sanity.DefaultDataset,
+//       sanity.WithCDN(true), sanity.WithToken("mytoken"))
+func New(projectID, dataset string, opts ...Option) (*Client, error) {
+	return VersionDefault.NewClient(projectID, dataset, opts...)
 }
 
 // NewClient returns a new versioned client. A project ID must be provided.

--- a/client.go
+++ b/client.go
@@ -163,7 +163,6 @@ func (v Version) NewClient(projectID, dataset string, opts ...Option) (*Client, 
 	}
 
 	setDefaultHeaders := func(r *requests.Request) {
-		r.Header("accept", "application/json")
 		r.Header("user-agent", "Sanity Go client/"+runtime.Version())
 		if c.token != "" {
 			r.Header("authorization", "Bearer "+c.token)

--- a/client_test.go
+++ b/client_test.go
@@ -16,6 +16,8 @@ func TestAuth(t *testing.T) {
 	withSuite(t, func(s *Suite) {
 		s.mux.Get("/v1/data/query/myDataset", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Bearer bork", r.Header.Get("Authorization"))
+			assert.Equal(t, "bar", r.Header.Get("foo"))
+			assert.Equal(t, []string{"application/json", "text/xml"}, r.Header.Values("accept"))
 
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write(mustJSONBytes(&api.QueryResponse{
@@ -27,5 +29,11 @@ func TestAuth(t *testing.T) {
 
 		_, err := s.client.Query("*").Do(context.Background())
 		require.NoError(t, err)
-	}, sanity.WithToken("bork"))
+	},
+		sanity.WithToken("bork"),
+		sanity.WithHTTPHeaders(map[string]string{
+			"foo":    "bar",
+			"accept": "text/xml",
+		}),
+	)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -9,21 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	sanity "github.com/sanity-io/client-go"
-	"github.com/sanity-io/client-go/api"
 )
 
-func TestAuth(t *testing.T) {
+func TestAuthorization(t *testing.T) {
 	withSuite(t, func(s *Suite) {
 		s.mux.Get("/v1/data/query/myDataset", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Bearer bork", r.Header.Get("Authorization"))
-			assert.Equal(t, "bar", r.Header.Get("foo"))
-			assert.Equal(t, []string{"application/json", "text/xml"}, r.Header.Values("accept"))
 
-			w.WriteHeader(http.StatusOK)
-			_, err := w.Write(mustJSONBytes(&api.QueryResponse{
-				Ms:     12,
-				Result: mustJSONMsg(nil),
-			}))
+			_, err := w.Write([]byte("{}"))
 			assert.NoError(t, err)
 		})
 
@@ -31,9 +24,61 @@ func TestAuth(t *testing.T) {
 		require.NoError(t, err)
 	},
 		sanity.WithToken("bork"),
-		sanity.WithHTTPHeaders(map[string]string{
-			"foo":    "bar",
-			"accept": "text/xml",
-		}),
 	)
+}
+
+func TestCustomHeaders(t *testing.T) {
+	withSuite(t, func(s *Suite) {
+		s.mux.Get("/v1/data/query/myDataset", func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "bar", r.Header.Get("foo"))
+			assert.Equal(t, []string{"application/json", "text/xml"}, r.Header.Values("accept"))
+
+			_, err := w.Write([]byte("{}"))
+			assert.NoError(t, err)
+		})
+
+		_, err := s.client.Query("*").Do(context.Background())
+		require.NoError(t, err)
+	},
+		sanity.WithHTTPHeader("foo", "bar"),
+		sanity.WithHTTPHeader("foo", "baz"), // Should be ignored
+		sanity.WithHTTPHeader("accept", "text/xml"),
+	)
+}
+
+func TestVersion_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		version sanity.Version
+		wantErr bool
+	}{
+		{
+			name:    "empty string",
+			version: sanity.Version(""),
+			wantErr: true,
+		},
+		{
+			name:    "invalid date format",
+			version: sanity.Version("2021-01"),
+			wantErr: true,
+		},
+		{
+			name:    "invalid date format",
+			version: sanity.Version("20210101"),
+			wantErr: true,
+		},
+		{
+			name:    "valid date version",
+			version: sanity.Version("2021-01-01"),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.version.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -5,29 +5,27 @@ import (
 	"net/http"
 	"testing"
 
-	sanity "github.com/sanity-io/client-go"
-	"github.com/sanity-io/client-go/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	sanity "github.com/sanity-io/client-go"
+	"github.com/sanity-io/client-go/api"
 )
 
 func TestAuth(t *testing.T) {
 	withSuite(t, func(s *Suite) {
-		client, err := s.client.WithOptions(sanity.WithToken("bork"))
-		require.NoError(t, err)
-
 		s.mux.Get("/v1/data/query/myDataset", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Bearer bork", r.Header.Get("Authorization"))
 
 			w.WriteHeader(http.StatusOK)
-			_, err = w.Write(mustJSONBytes(&api.QueryResponse{
+			_, err := w.Write(mustJSONBytes(&api.QueryResponse{
 				Ms:     12,
 				Result: mustJSONMsg(nil),
 			}))
 			assert.NoError(t, err)
 		})
 
-		_, err = client.Query("*").Do(context.Background())
+		_, err := s.client.Query("*").Do(context.Background())
 		require.NoError(t, err)
-	})
+	}, sanity.WithToken("bork"))
 }

--- a/errors.go
+++ b/errors.go
@@ -32,3 +32,14 @@ func (e *RequestError) Error() string {
 	}
 	return msg
 }
+
+// InvalidRequestError is returned when builder errors on creating API request object.
+type InvalidRequestError struct {
+	// Description is the reason for error.
+	Description string
+}
+
+// Error implements the error interface.
+func (e *InvalidRequestError) Error() string {
+	return e.Description
+}

--- a/errors.go
+++ b/errors.go
@@ -32,14 +32,3 @@ func (e *RequestError) Error() string {
 	}
 	return msg
 }
-
-// InvalidRequestError is returned when builder errors on creating API request object.
-type InvalidRequestError struct {
-	// Description is the reason for error.
-	Description string
-}
-
-// Error implements the error interface.
-func (e *InvalidRequestError) Error() string {
-	return e.Description
-}

--- a/get_documents.go
+++ b/get_documents.go
@@ -1,0 +1,51 @@
+package sanity
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sanity-io/client-go/api"
+	"github.com/sanity-io/client-go/internal/requests"
+)
+
+// GetDocuments returns a new GetDocuments builder.
+func (c *Client) GetDocuments(docIDs ...string) *GetDocumentsBuilder {
+	return &GetDocumentsBuilder{c: c, docIDs: docIDs}
+}
+
+// QueryBuilder is a builder for GET documents API.
+type GetDocumentsBuilder struct {
+	c      *Client
+	docIDs []string
+}
+
+// Do performs the query.
+// On validation failure, this will return an error of *InvalidRequestError.
+// On API request failure, this will return an error of type *RequestError.
+func (b *GetDocumentsBuilder) Do(ctx context.Context) (*api.GetDocumentsResponse, error) {
+	req, err := b.buildGET()
+	if err != nil {
+		return nil, err
+	}
+
+	var resp api.GetDocumentsResponse
+	if _, err := b.c.do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (b *GetDocumentsBuilder) buildGET() (*requests.Request, error) {
+	if len(b.docIDs) == 0 {
+		return nil, &InvalidRequestError{Description: "no document ID specified"}
+	}
+
+	req := b.c.newAPIRequest().
+		AppendPath("data/doc", b.c.dataset, strings.Join(b.docIDs, ","))
+
+	if len(req.EncodeURL()) > maxGETRequestURLLength {
+		return nil, &InvalidRequestError{Description: "max URL length exceeded"}
+	}
+	return req, nil
+}

--- a/get_documents.go
+++ b/get_documents.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/sanity-io/client-go/api"
-	"github.com/sanity-io/client-go/internal/requests"
 )
 
 // GetDocuments returns a new GetDocuments builder.
@@ -20,13 +19,14 @@ type GetDocumentsBuilder struct {
 }
 
 // Do performs the query.
-// On validation failure, this will return an error of *InvalidRequestError.
 // On API request failure, this will return an error of type *RequestError.
 func (b *GetDocumentsBuilder) Do(ctx context.Context) (*api.GetDocumentsResponse, error) {
-	req, err := b.buildGET()
-	if err != nil {
-		return nil, err
+	if len(b.docIDs) == 0 {
+		return &api.GetDocumentsResponse{}, nil
 	}
+
+	req := b.c.newAPIRequest().
+		AppendPath("data/doc", b.c.dataset, strings.Join(b.docIDs, ","))
 
 	var resp api.GetDocumentsResponse
 	if _, err := b.c.do(ctx, req, &resp); err != nil {
@@ -34,18 +34,4 @@ func (b *GetDocumentsBuilder) Do(ctx context.Context) (*api.GetDocumentsResponse
 	}
 
 	return &resp, nil
-}
-
-func (b *GetDocumentsBuilder) buildGET() (*requests.Request, error) {
-	if len(b.docIDs) == 0 {
-		return nil, &InvalidRequestError{Description: "no document ID specified"}
-	}
-
-	req := b.c.newAPIRequest().
-		AppendPath("data/doc", b.c.dataset, strings.Join(b.docIDs, ","))
-
-	if len(req.EncodeURL()) > maxGETRequestURLLength {
-		return nil, &InvalidRequestError{Description: "max URL length exceeded"}
-	}
-	return req, nil
 }

--- a/get_documents_test.go
+++ b/get_documents_test.go
@@ -37,11 +37,9 @@ func TestGetDocuments(t *testing.T) {
 
 	t.Run("No document ID specified", func(t *testing.T) {
 		withSuite(t, func(s *Suite) {
-			_, err := s.client.GetDocuments().Do(context.Background())
-			require.Error(t, err)
-
-			var reqErr *sanity.InvalidRequestError
-			require.True(t, errors.As(err, &reqErr))
+			resp, err := s.client.GetDocuments().Do(context.Background())
+			require.NoError(t, err)
+			require.Nil(t, resp.Documents)
 		})
 	})
 
@@ -67,9 +65,6 @@ func TestGetDocuments(t *testing.T) {
 			}
 			_, err := s.client.GetDocuments(string(docID)).Do(context.Background())
 			require.Error(t, err)
-
-			var reqErr *sanity.InvalidRequestError
-			require.True(t, errors.As(err, &reqErr))
 		})
 	})
 

--- a/get_documents_test.go
+++ b/get_documents_test.go
@@ -1,0 +1,78 @@
+package sanity_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sanity "github.com/sanity-io/client-go"
+	"github.com/sanity-io/client-go/api"
+)
+
+func TestGetDocuments(t *testing.T) {
+	docIDs := []string{"doc1", "doc2"}
+	now := time.Date(2020, 1, 2, 23, 01, 44, 0, time.UTC)
+	testDoc1 := &testDocument{
+		ID:        "doc1",
+		Type:      "doc",
+		CreatedAt: now,
+		UpdatedAt: now,
+		Value:     "hello world",
+	}
+
+	testDoc2 := &testDocument{
+		ID:        "doc2",
+		Type:      "doc",
+		CreatedAt: now,
+		UpdatedAt: now,
+		Value:     "hello world",
+	}
+
+	testDocuments := []api.Document{testDoc1.toMap(), testDoc2.toMap()}
+
+	t.Run("GET URL length exceeded", func(t *testing.T) {
+		withSuite(t, func(s *Suite) {
+			docID := make([]rune, 1024)
+			for i := range docID {
+				docID[i] = 'x'
+			}
+			_, err := s.client.GetDocuments(string(docID)).Do(context.Background())
+			require.Error(t, err)
+
+			var reqErr *sanity.InvalidRequestError
+			require.True(t, errors.As(err, &reqErr))
+		})
+	})
+
+	t.Run("get 2 documents", func(t *testing.T) {
+		withSuite(t, func(s *Suite) {
+			s.mux.Get("/v1/data/doc/myDataset/doc1,doc2", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, err := w.Write(mustJSONBytes(&api.GetDocumentsResponse{
+					Documents: testDocuments,
+				}))
+				assert.NoError(t, err)
+			})
+
+			result, err := s.client.GetDocuments(docIDs...).Do(context.Background())
+			require.NoError(t, err)
+
+			assert.Equal(t, testDocuments, result.Documents)
+		})
+	})
+
+	t.Run("No document ID specified", func(t *testing.T) {
+		withSuite(t, func(s *Suite) {
+			_, err := s.client.GetDocuments().Do(context.Background())
+			require.Error(t, err)
+
+			var reqErr *sanity.InvalidRequestError
+			require.True(t, errors.As(err, &reqErr))
+		})
+	})
+}

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -67,7 +67,8 @@ func (b *Request) Path(elems ...string) *Request {
 
 func (b *Request) AppendPath(elems ...string) *Request {
 	for _, elem := range elems {
-		if (b.path == "" || b.path[len(b.path)-1] != '/') && elem[0] != '/' {
+		if (b.path == "" || b.path[len(b.path)-1] != '/') &&
+			(len(elem) > 0 && elem[0] != '/') {
 			b.path += "/"
 		}
 		b.path += elem

--- a/internal/requests/requests_test.go
+++ b/internal/requests/requests_test.go
@@ -1,0 +1,72 @@
+package requests_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sanity-io/client-go/internal/requests"
+)
+
+func TestRequest_AppendPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		elems []string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			elems: []string{""},
+			want:  "//localhost",
+		},
+		{
+			name:  "with path",
+			elems: []string{"foo"},
+			want:  "//localhost/foo",
+		},
+		{
+			name:  "with multiple paths",
+			elems: []string{"foo", "bar"},
+			want:  "//localhost/foo/bar",
+		},
+		{
+			name:  "with multiple paths and empty string",
+			elems: []string{"foo", "", "bar"},
+			want:  "//localhost/foo/bar",
+		},
+		{
+			name:  "with empty string at the start",
+			elems: []string{"", "foo", "bar"},
+			want:  "//localhost/foo/bar",
+		},
+		{
+			name:  "with empty string at the end",
+			elems: []string{"foo", "bar", ""},
+			want:  "//localhost/foo/bar",
+		},
+		{
+			name:  "with slash in path string",
+			elems: []string{"foo", "/", "bar"},
+			want:  "//localhost/foo/bar",
+		},
+		{
+			name:  "with slash in path string at the start",
+			elems: []string{"/", "foo", "bar"},
+			want:  "//localhost/foo/bar",
+		},
+		{
+			name:  "with slash in path string at the end",
+			elems: []string{"foo", "/", "bar"},
+			want:  "//localhost/foo/bar",
+		},
+	}
+	baseURL := url.URL{Host: "localhost"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := requests.New(baseURL)
+			got := r.AppendPath(tt.elems...)
+			require.Equal(t, got.EncodeURL(), tt.want)
+		})
+	}
+}

--- a/mutation.go
+++ b/mutation.go
@@ -75,7 +75,8 @@ func (mb *MutationBuilder) Do(ctx context.Context) (*MutateResult, error) {
 	}
 
 	return &MutateResult{
-		Results: resp.Results,
+		TransactionID: resp.TransactionID,
+		Results:       resp.Results,
 	}, nil
 }
 

--- a/mutation.go
+++ b/mutation.go
@@ -58,7 +58,7 @@ func (mb *MutationBuilder) Do(ctx context.Context) (*MutateResult, error) {
 		return nil, fmt.Errorf("mutation builder: %w", mb.err)
 	}
 
-	req := mb.c.newRequest().
+	req := mb.c.newAPIRequest().
 		Method(http.MethodPost).
 		AppendPath("data/mutate", mb.c.dataset).
 		Param("returnIds", mb.returnIDs).

--- a/package_test.go
+++ b/package_test.go
@@ -52,6 +52,19 @@ type testDocument struct {
 	Value     string    `json:"value"`
 }
 
+func (d testDocument) toMap() map[string]interface{} {
+	m, err := json.Marshal(d)
+	if err != nil {
+		panic(err)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal(m, &doc); err != nil {
+		panic(err)
+	}
+	return doc
+}
+
 type testDocumentWithCustomJSONMarshaler struct{}
 
 func (testDocumentWithCustomJSONMarshaler) MarshalJSON() ([]byte, error) {

--- a/package_test.go
+++ b/package_test.go
@@ -36,7 +36,7 @@ func withSuite(t *testing.T, f func(*Suite), opts ...sanity.Option) {
 
 	opts = append(opts, sanity.WithBaseURL(*url), sanity.WithDataset("myDataset"))
 
-	c, err := sanity.New("myProject", opts...)
+	c, err := sanity.VersionV1.NewClient("myProject", opts...)
 	require.NoError(t, err)
 
 	suite.client = c

--- a/package_test.go
+++ b/package_test.go
@@ -34,9 +34,9 @@ func withSuite(t *testing.T, f func(*Suite), opts ...sanity.Option) {
 	require.NoError(t, err)
 	url.Path = "/v1"
 
-	opts = append(opts, sanity.WithBaseURL(*url), sanity.WithDataset("myDataset"))
+	opts = append(opts, sanity.WithHTTPHost(url.Scheme, url.Host))
 
-	c, err := sanity.VersionV1.NewClient("myProject", opts...)
+	c, err := sanity.VersionV1.NewClient("myProject", "myDataset", opts...)
 	require.NoError(t, err)
 
 	suite.client = c

--- a/query.go
+++ b/query.go
@@ -123,5 +123,3 @@ func (qb *QueryBuilder) buildPOST() (*requests.Request, error) {
 		AppendPath("data/query", qb.c.dataset).
 		MarshalBody(request), nil
 }
-
-const maxGETRequestURLLength = 1024

--- a/query.go
+++ b/query.go
@@ -91,7 +91,7 @@ func (qb *QueryBuilder) Do(ctx context.Context) (*QueryResult, error) {
 }
 
 func (qb *QueryBuilder) buildGET() (*requests.Request, error) {
-	req := qb.c.newRequest().
+	req := qb.c.newQueryRequest().
 		AppendPath("data/query", qb.c.dataset).
 		Param("query", qb.query)
 	for p, v := range qb.params {
@@ -118,7 +118,7 @@ func (qb *QueryBuilder) buildPOST() (*requests.Request, error) {
 		request.Params[p] = (*json.RawMessage)(&b)
 	}
 
-	return qb.c.newRequest().
+	return qb.c.newQueryRequest().
 		Method(http.MethodPost).
 		AppendPath("data/query", qb.c.dataset).
 		MarshalBody(request), nil


### PR DESCRIPTION
Also includes:
1. Set `User-Agent` header in requests to remote.
1. Fix bug where setting `useCDN` would cause mutations to go to APICDN.