### PR TITLE
Allow setting custom headers on Client

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -9,7 +9,8 @@ type MutateRequest struct {
 }
 
 type MutateResponse struct {
-	Results []*MutateResultItem `json:"results"`
+	TransactionID string              `json:"transactionId"`
+	Results       []*MutateResultItem `json:"results"`
 }
 
 type MutationItem struct {

--- a/client.go
+++ b/client.go
@@ -163,7 +163,6 @@ func (v Version) NewClient(projectID, dataset string, opts ...Option) (*Client, 
 	}
 
 	setDefaultHeaders := func(r *requests.Request) {
-		r.Header("accept", "application/json")
 		r.Header("user-agent", "Sanity Go client/"+runtime.Version())
 		if c.token != "" {
 			r.Header("authorization", "Bearer "+c.token)

--- a/client_test.go
+++ b/client_test.go
@@ -16,6 +16,8 @@ func TestAuth(t *testing.T) {
 	withSuite(t, func(s *Suite) {
 		s.mux.Get("/v1/data/query/myDataset", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Bearer bork", r.Header.Get("Authorization"))
+			assert.Equal(t, "bar", r.Header.Get("foo"))
+			assert.Equal(t, []string{"application/json", "text/xml"}, r.Header.Values("accept"))
 
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write(mustJSONBytes(&api.QueryResponse{
@@ -27,5 +29,11 @@ func TestAuth(t *testing.T) {
 
 		_, err := s.client.Query("*").Do(context.Background())
 		require.NoError(t, err)
-	}, sanity.WithToken("bork"))
+	},
+		sanity.WithToken("bork"),
+		sanity.WithHTTPHeaders(map[string]string{
+			"foo":    "bar",
+			"accept": "text/xml",
+		}),
+	)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -9,21 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	sanity "github.com/sanity-io/client-go"
-	"github.com/sanity-io/client-go/api"
 )
 
-func TestAuth(t *testing.T) {
+func TestAuthorization(t *testing.T) {
 	withSuite(t, func(s *Suite) {
 		s.mux.Get("/v1/data/query/myDataset", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Bearer bork", r.Header.Get("Authorization"))
-			assert.Equal(t, "bar", r.Header.Get("foo"))
-			assert.Equal(t, []string{"application/json", "text/xml"}, r.Header.Values("accept"))
 
-			w.WriteHeader(http.StatusOK)
-			_, err := w.Write(mustJSONBytes(&api.QueryResponse{
-				Ms:     12,
-				Result: mustJSONMsg(nil),
-			}))
+			_, err := w.Write([]byte("{}"))
 			assert.NoError(t, err)
 		})
 
@@ -31,9 +24,61 @@ func TestAuth(t *testing.T) {
 		require.NoError(t, err)
 	},
 		sanity.WithToken("bork"),
-		sanity.WithHTTPHeaders(map[string]string{
-			"foo":    "bar",
-			"accept": "text/xml",
-		}),
 	)
+}
+
+func TestCustomHeaders(t *testing.T) {
+	withSuite(t, func(s *Suite) {
+		s.mux.Get("/v1/data/query/myDataset", func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "bar", r.Header.Get("foo"))
+			assert.Equal(t, []string{"application/json", "text/xml"}, r.Header.Values("accept"))
+
+			_, err := w.Write([]byte("{}"))
+			assert.NoError(t, err)
+		})
+
+		_, err := s.client.Query("*").Do(context.Background())
+		require.NoError(t, err)
+	},
+		sanity.WithHTTPHeader("foo", "bar"),
+		sanity.WithHTTPHeader("foo", "baz"), // Should be ignored
+		sanity.WithHTTPHeader("accept", "text/xml"),
+	)
+}
+
+func TestVersion_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		version sanity.Version
+		wantErr bool
+	}{
+		{
+			name:    "empty string",
+			version: sanity.Version(""),
+			wantErr: true,
+		},
+		{
+			name:    "invalid date format",
+			version: sanity.Version("2021-01"),
+			wantErr: true,
+		},
+		{
+			name:    "invalid date format",
+			version: sanity.Version("20210101"),
+			wantErr: true,
+		},
+		{
+			name:    "valid date version",
+			version: sanity.Version("2021-01-01"),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.version.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -67,7 +67,8 @@ func (b *Request) Path(elems ...string) *Request {
 
 func (b *Request) AppendPath(elems ...string) *Request {
 	for _, elem := range elems {
-		if (b.path == "" || b.path[len(b.path)-1] != '/') && elem[0] != '/' {
+		if (b.path == "" || b.path[len(b.path)-1] != '/') &&
+			(len(elem) > 0 && elem[0] != '/') {
 			b.path += "/"
 		}
 		b.path += elem

--- a/internal/requests/requests_test.go
+++ b/internal/requests/requests_test.go
@@ -1,0 +1,72 @@
+package requests_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sanity-io/client-go/internal/requests"
+)
+
+func TestRequest_AppendPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		elems []string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			elems: []string{""},
+			want:  "//localhost",
+		},
+		{
+			name:  "with path",
+			elems: []string{"foo"},
+			want:  "//localhost/foo",
+		},
+		{
+			name:  "with multiple paths",
+			elems: []string{"foo", "bar"},
+			want:  "//localhost/foo/bar",
+		},
+		{
+			name:  "with multiple paths and empty string",
+			elems: []string{"foo", "", "bar"},
+			want:  "//localhost/foo/bar",
+		},
+		{
+			name:  "with empty string at the start",
+			elems: []string{"", "foo", "bar"},
+			want:  "//localhost/foo/bar",
+		},
+		{
+			name:  "with empty string at the end",
+			elems: []string{"foo", "bar", ""},
+			want:  "//localhost/foo/bar",
+		},
+		{
+			name:  "with slash in path string",
+			elems: []string{"foo", "/", "bar"},
+			want:  "//localhost/foo/bar",
+		},
+		{
+			name:  "with slash in path string at the start",
+			elems: []string{"/", "foo", "bar"},
+			want:  "//localhost/foo/bar",
+		},
+		{
+			name:  "with slash in path string at the end",
+			elems: []string{"foo", "/", "bar"},
+			want:  "//localhost/foo/bar",
+		},
+	}
+	baseURL := url.URL{Host: "localhost"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := requests.New(baseURL)
+			got := r.AppendPath(tt.elems...)
+			require.Equal(t, got.EncodeURL(), tt.want)
+		})
+	}
+}

--- a/mutation.go
+++ b/mutation.go
@@ -75,7 +75,8 @@ func (mb *MutationBuilder) Do(ctx context.Context) (*MutateResult, error) {
 	}
 
 	return &MutateResult{
-		Results: resp.Results,
+		TransactionID: resp.TransactionID,
+		Results:       resp.Results,
 	}, nil
 }
 


### PR DESCRIPTION
1. Allow setting custom headers on Client.
2. Fixes a bug where `Accept` header was being set twice.
3. Fixes bug where empty string to path append would panic
4. Returns `transactionId` for mutation in mutation results.