### PR TITLE
feat(mutation): add dry run option

### DIFF
--- a/mutation.go
+++ b/mutation.go
@@ -31,6 +31,7 @@ type MutationBuilder struct {
 	returnDocs    bool
 	visibility    api.MutationVisibility
 	transactionID string
+	dryRun        bool
 }
 
 func (mb *MutationBuilder) Visibility(v api.MutationVisibility) *MutationBuilder {
@@ -53,6 +54,11 @@ func (mb *MutationBuilder) ReturnDocuments(enable bool) *MutationBuilder {
 	return mb
 }
 
+func (mb *MutationBuilder) DryRun(enable bool) *MutationBuilder {
+	mb.dryRun = enable
+	return mb
+}
+
 func (mb *MutationBuilder) Do(ctx context.Context) (*MutateResult, error) {
 	if mb.err != nil {
 		return nil, fmt.Errorf("mutation builder: %w", mb.err)
@@ -64,6 +70,7 @@ func (mb *MutationBuilder) Do(ctx context.Context) (*MutateResult, error) {
 		Param("returnIds", mb.returnIDs).
 		Param("returnDocuments", mb.returnDocs).
 		Param("visibility", string(mb.visibility)).
+		Param("dryRun", mb.dryRun).
 		MarshalBody(&api.MutateRequest{Mutations: mb.items})
 	if mb.transactionID != "" {
 		req.Param("transactionId", mb.transactionID)

--- a/mutation_test.go
+++ b/mutation_test.go
@@ -427,3 +427,33 @@ func TestMutation_Builder_visibilityOption(t *testing.T) {
 		})
 	})
 }
+
+func TestMutation_Builder_dryRunOption(t *testing.T) {
+	t.Run("can be set to true", func(t *testing.T) {
+		withSuite(t, func(s *Suite) {
+			s.mux.Post("/v1/data/mutate/myDataset", func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "true", r.URL.Query().Get("dryRun"))
+				w.WriteHeader(http.StatusOK)
+				_, err := w.Write(mustJSONBytes(&api.MutateResponse{}))
+				assert.NoError(t, err)
+			})
+
+			_, err := s.client.Mutate().DryRun(true).Do(context.Background())
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("defaults to false", func(t *testing.T) {
+		withSuite(t, func(s *Suite) {
+			s.mux.Post("/v1/data/mutate/myDataset", func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "false", r.URL.Query().Get("dryRun"))
+				w.WriteHeader(http.StatusOK)
+				_, err := w.Write(mustJSONBytes(&api.MutateResponse{}))
+				assert.NoError(t, err)
+			})
+
+			_, err := s.client.Mutate().Do(context.Background())
+			require.NoError(t, err)
+		})
+	})
+}


### PR DESCRIPTION
Expose the `dryRun` parameter on the mutation options.

Ref: https://www.sanity.io/docs/http-mutations#dryRun-cd0dae296271