### PR TITLE
Add listen API support

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -87,3 +87,10 @@ type GetDocumentsResponse struct {
 
 // Document is a map of document attributes
 type Document map[string]interface{}
+
+// ListenEvent represents a single event from the listen API.
+type ListenEvent struct {
+	Type string
+	ID   string
+	Data *json.RawMessage
+}

--- a/client.go
+++ b/client.go
@@ -143,8 +143,8 @@ func WithTag(t string) Option {
 // New returns a new client with a default API version. A project ID must be provided.
 // Zero or more options can be passed. For example:
 //
-//     client := sanity.New("projectId", sanity.DefaultDataset,
-//       sanity.WithCDN(true), sanity.WithToken("mytoken"))
+//	client := sanity.New("projectId", sanity.DefaultDataset,
+//	  sanity.WithCDN(true), sanity.WithToken("mytoken"))
 func New(projectID, dataset string, opts ...Option) (*Client, error) {
 	return VersionDefault.NewClient(projectID, dataset, opts...)
 }
@@ -152,9 +152,8 @@ func New(projectID, dataset string, opts ...Option) (*Client, error) {
 // NewClient returns a new versioned client. A project ID must be provided.
 // Zero or more options can be passed. For example:
 //
-//     client := sanity.VersionV20210325.NewClient("projectId", sanity.DefaultDataset,
-//       sanity.WithCDN(true), sanity.WithToken("mytoken"))
-//
+//	client := sanity.VersionV20210325.NewClient("projectId", sanity.DefaultDataset,
+//	  sanity.WithCDN(true), sanity.WithToken("mytoken"))
 func (v Version) NewClient(projectID, dataset string, opts ...Option) (*Client, error) {
 	if projectID == "" {
 		return nil, errors.New("project ID cannot be empty")
@@ -267,6 +266,38 @@ func (c *Client) handleErrorResponse(req *http.Request, resp *http.Response) err
 		Request:  req,
 		Response: resp,
 		Body:     body,
+	}
+}
+
+func (c *Client) doRaw(ctx context.Context, r *requests.Request) (*http.Response, error) {
+	req, err := r.HTTPRequest()
+	if err != nil {
+		return nil, err
+	}
+	if host := req.Header.Get("host"); host != "" {
+		req.Host = host
+	}
+	if req.Method == http.MethodGet && len(r.EncodeURL()) > maxGETRequestURLLength {
+		return nil, errors.New("max URL length exceeded in GET request")
+	}
+	req = req.WithContext(ctx)
+	bckoff := c.backoff
+	for {
+		resp, err := c.hc.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("[%s %s] failed: %w", req.Method, req.URL.String(), err)
+		}
+		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+			return resp, nil
+		}
+		if !isMethodRetriable(req.Method) || !isStatusCodeRetriable(resp.StatusCode) {
+			return nil, c.handleErrorResponse(req, resp)
+		}
+		_ = resp.Body.Close()
+		if c.callbacks.OnErrorWillRetry != nil {
+			c.callbacks.OnErrorWillRetry(err)
+		}
+		time.Sleep(bckoff.Duration())
 	}
 }
 

--- a/listen.go
+++ b/listen.go
@@ -1,0 +1,130 @@
+package sanity
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/sanity-io/client-go/api"
+)
+
+// Listen returns a new builder for the listen API.
+func (c *Client) Listen(query string) *ListenBuilder {
+	return &ListenBuilder{c: c, query: query}
+}
+
+type ListenBuilder struct {
+	c             *Client
+	query         string
+	params        map[string]interface{}
+	includeResult bool
+	tag           string
+}
+
+// Param adds a parameter to the listen query.
+func (lb *ListenBuilder) Param(name string, val interface{}) *ListenBuilder {
+	if lb.params == nil {
+		lb.params = make(map[string]interface{}, 10)
+	}
+	lb.params[name] = val
+	return lb
+}
+
+// IncludeResult controls whether the event payload contains the document.
+func (lb *ListenBuilder) IncludeResult(b bool) *ListenBuilder {
+	lb.includeResult = b
+	return lb
+}
+
+// Tag sets a custom tag on the request.
+func (lb *ListenBuilder) Tag(tag string) *ListenBuilder {
+	lb.tag = tag
+	return lb
+}
+
+// Do starts the listen stream and returns a ListenStream.
+func (lb *ListenBuilder) Do(ctx context.Context) (*ListenStream, error) {
+	req := lb.c.newQueryRequest().
+		AppendPath("data/listen", lb.c.dataset).
+		Param("query", lb.query).
+		Header("accept", "text/event-stream").
+		Tag(lb.tag, lb.c.tag)
+
+	for p, v := range lb.params {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling parameter %q to JSON: %w", p, err)
+		}
+		req.Param("$"+p, string(b))
+	}
+	if lb.includeResult {
+		req.Param("includeResult", true)
+	}
+
+	resp, err := lb.c.doRaw(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ListenStream{resp: resp, r: bufio.NewReader(resp.Body)}, nil
+}
+
+// ListenStream represents a stream of listen events.
+type ListenStream struct {
+	resp *http.Response
+	r    *bufio.Reader
+}
+
+// Close closes the underlying HTTP connection.
+func (ls *ListenStream) Close() error {
+	if ls.resp != nil && ls.resp.Body != nil {
+		return ls.resp.Body.Close()
+	}
+	return nil
+}
+
+// Next reads the next event from the stream. It returns io.EOF when the
+// connection is closed.
+func (ls *ListenStream) Next() (*api.ListenEvent, error) {
+	var (
+		eventType string
+		id        string
+		dataBuf   bytes.Buffer
+	)
+
+	for {
+		line, err := ls.r.ReadString('\n')
+		if err != nil {
+			if err == io.EOF && dataBuf.Len() == 0 {
+				return nil, io.EOF
+			}
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" { // end of event
+			if dataBuf.Len() == 0 {
+				// keep reading until we get a data line
+				continue
+			}
+			data := dataBuf.Bytes()
+			var payload json.RawMessage = append([]byte(nil), data...)
+			return &api.ListenEvent{Type: eventType, ID: id, Data: &payload}, nil
+		}
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			eventType = strings.TrimSpace(line[len("event:"):])
+		case strings.HasPrefix(line, "id:"):
+			id = strings.TrimSpace(line[len("id:"):])
+		case strings.HasPrefix(line, "data:"):
+			if dataBuf.Len() > 0 {
+				dataBuf.WriteByte('\n')
+			}
+			dataBuf.WriteString(strings.TrimSpace(line[len("data:"):]))
+		}
+	}
+}

--- a/listen_test.go
+++ b/listen_test.go
@@ -1,0 +1,35 @@
+package sanity_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListen_basic(t *testing.T) {
+	withSuite(t, func(s *Suite) {
+		s.mux.Get("/v1/data/listen/myDataset", func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "*[_type == \"test\"]", r.URL.Query().Get("query"))
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher, ok := w.(http.Flusher)
+			require.True(t, ok)
+			fmt.Fprint(w, "event: mutation\nid:1\ndata:{\"foo\":\"bar\"}\n\n")
+			flusher.Flush()
+		})
+		stream, err := s.client.Listen("*[_type == \"test\"]").Do(context.Background())
+		require.NoError(t, err)
+		event, err := stream.Next()
+		require.NoError(t, err)
+		require.NoError(t, stream.Close())
+		assert.Equal(t, "mutation", event.Type)
+		assert.Equal(t, "1", event.ID)
+		var m map[string]string
+		require.NoError(t, json.Unmarshal(*event.Data, &m))
+		assert.Equal(t, "bar", m["foo"])
+	})
+}


### PR DESCRIPTION
We have listener API which is public but is not supported by Go client. This PR adds support for it.

This change was tested locally with this Go program:
```go
package main

import (
	"context"
	"log"

	sanity "github.com/sanity-io/client-go"
)

func main() {
	client, err := sanity.VersionV20210325.NewClient("myProjectId", sanity.DefaultDataset,
		sanity.WithCallbacks(sanity.Callbacks{
			OnQueryResult: func(result *sanity.QueryResult) {
				log.Printf("Sanity queried in %d ms!", result.Time.Milliseconds())
			},
		}))
	if err != nil {
		log.Fatal(err)
	}

	ctx := context.Background()
	result, err := client.Listen("*").Do(ctx)
	if err != nil {
		log.Fatal(err)
	}

	for {
		event, err := result.Next()
		if err != nil {
			log.Fatal(err)
		}
		log.Printf("Event =>")
		log.Printf("\tType: %s", event.Type)
		log.Printf("\tID: %s", event.ID)
		log.Printf("\tData: %s\n\n", string(*event.Data))
	}
}
```