### PR TITLE
Add basic Actions API

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -1,0 +1,75 @@
+package sanity
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/sanity-io/client-go/api"
+)
+
+// Actions returns a new actions builder.
+func (c *Client) Actions() *ActionsBuilder {
+	return &ActionsBuilder{c: c}
+}
+
+type ActionsBuilder struct {
+	c                                   *Client
+	actions                             []interface{}
+	transactionID                       string
+	skipCrossDatasetReferenceValidation bool
+	dryRun                              bool
+	tag                                 string
+}
+
+// Action appends an action to perform.
+func (b *ActionsBuilder) Action(a interface{}) *ActionsBuilder {
+	b.actions = append(b.actions, a)
+	return b
+}
+
+// TransactionID sets the transaction ID.
+func (b *ActionsBuilder) TransactionID(id string) *ActionsBuilder {
+	b.transactionID = id
+	return b
+}
+
+// SkipCrossDatasetReferenceValidation disables cross dataset reference validation.
+func (b *ActionsBuilder) SkipCrossDatasetReferenceValidation(v bool) *ActionsBuilder {
+	b.skipCrossDatasetReferenceValidation = v
+	return b
+}
+
+// DryRun performs the actions without applying them.
+func (b *ActionsBuilder) DryRun(v bool) *ActionsBuilder {
+	b.dryRun = v
+	return b
+}
+
+// Tag sets a custom request tag.
+func (b *ActionsBuilder) Tag(tag string) *ActionsBuilder {
+	b.tag = tag
+	return b
+}
+
+// Do performs the actions.
+func (b *ActionsBuilder) Do(ctx context.Context) (*api.ActionsResponse, error) {
+	reqBody := &api.ActionsRequest{
+		Actions:                             b.actions,
+		TransactionID:                       b.transactionID,
+		SkipCrossDatasetReferenceValidation: b.skipCrossDatasetReferenceValidation,
+		DryRun:                              b.dryRun,
+	}
+
+	req := b.c.newAPIRequest().
+		Method(http.MethodPost).
+		AppendPath("data/actions", b.c.dataset).
+		MarshalBody(reqBody).
+		Tag(b.tag, b.c.tag)
+
+	var resp api.ActionsResponse
+	if _, err := b.c.do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("actions: %w", err)
+	}
+	return &resp, nil
+}

--- a/actions_test.go
+++ b/actions_test.go
@@ -1,0 +1,57 @@
+package sanity_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sanity-io/client-go/api"
+)
+
+func TestActions_basic(t *testing.T) {
+	withSuite(t, func(s *Suite) {
+		s.mux.Post("/v1/data/actions/myDataset", func(w http.ResponseWriter, r *http.Request) {
+			var body api.ActionsRequest
+			err := json.NewDecoder(r.Body).Decode(&body)
+			require.NoError(t, err)
+			assert.Equal(t, "test-tx", body.TransactionID)
+			assert.Equal(t, true, body.DryRun)
+			if assert.Len(t, body.Actions, 1) {
+				m, ok := body.Actions[0].(map[string]interface{})
+				require.True(t, ok)
+				assert.Equal(t, "sanity.action.document.create", m["actionType"])
+			}
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(mustJSONBytes(&api.ActionsResponse{}))
+			assert.NoError(t, err)
+		})
+
+		action := map[string]interface{}{"actionType": "sanity.action.document.create"}
+		_, err := s.client.Actions().Action(action).TransactionID("test-tx").DryRun(true).Do(context.Background())
+		require.NoError(t, err)
+	})
+}
+
+func TestActions_defaults(t *testing.T) {
+	withSuite(t, func(s *Suite) {
+		s.mux.Post("/v1/data/actions/myDataset", func(w http.ResponseWriter, r *http.Request) {
+			var body api.ActionsRequest
+			err := json.NewDecoder(r.Body).Decode(&body)
+			require.NoError(t, err)
+			assert.Equal(t, "", body.TransactionID)
+			assert.Equal(t, false, body.DryRun)
+			assert.False(t, body.SkipCrossDatasetReferenceValidation)
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(mustJSONBytes(&api.ActionsResponse{}))
+			assert.NoError(t, err)
+		})
+
+		action := map[string]interface{}{"actionType": "x"}
+		_, err := s.client.Actions().Action(action).Do(context.Background())
+		require.NoError(t, err)
+	})
+}

--- a/api/types.go
+++ b/api/types.go
@@ -94,3 +94,162 @@ type ListenEvent struct {
 	ID   string
 	Data *json.RawMessage
 }
+
+// ActionsRequest represents a request to the actions API.
+type ActionsRequest struct {
+	Actions                             []interface{} `json:"actions"`
+	TransactionID                       string        `json:"transactionId,omitempty"`
+	SkipCrossDatasetReferenceValidation bool          `json:"skipCrossDatasetReferenceValidation,omitempty"`
+	DryRun                              bool          `json:"dryRun,omitempty"`
+}
+
+// ActionsResponse holds the result of an actions API call.
+type ActionsResponse struct {
+	TransactionID string `json:"transactionId"`
+}
+
+// DocumentCreateAction represents a document.create action.
+type DocumentCreateAction struct {
+	ActionType  string           `json:"actionType"`
+	PublishedID string           `json:"publishedId"`
+	IfExists    string           `json:"ifExists,omitempty"`
+	Document    *json.RawMessage `json:"document"`
+}
+
+// DocumentDeleteAction represents a document.delete action.
+type DocumentDeleteAction struct {
+	ActionType    string   `json:"actionType"`
+	PublishedID   string   `json:"publishedId"`
+	IncludeDrafts []string `json:"includeDrafts,omitempty"`
+	Purge         bool     `json:"purge,omitempty"`
+}
+
+// DocumentDiscardAction represents a document.discard action (deprecated).
+type DocumentDiscardAction struct {
+	ActionType string `json:"actionType"`
+	VersionID  string `json:"versionId"`
+	Purge      bool   `json:"purge,omitempty"`
+}
+
+// DocumentEditAction represents a document.edit action.
+type DocumentEditAction struct {
+	ActionType  string           `json:"actionType"`
+	PublishedID string           `json:"publishedId"`
+	VersionID   string           `json:"versionId"`
+	Patch       *json.RawMessage `json:"patch"`
+}
+
+// DocumentPublishAction represents a document.publish action.
+type DocumentPublishAction struct {
+	ActionType            string `json:"actionType"`
+	PublishedID           string `json:"publishedId"`
+	VersionID             string `json:"versionId"`
+	IfDraftRevisionID     string `json:"ifDraftRevisionId,omitempty"`
+	IfPublishedRevisionID string `json:"ifPublishedRevisionId,omitempty"`
+}
+
+// DocumentUnpublishAction represents a document.unpublish action.
+type DocumentUnpublishAction struct {
+	ActionType  string `json:"actionType"`
+	PublishedID string `json:"publishedId"`
+	VersionID   string `json:"versionId"`
+}
+
+// DocumentReplaceDraftAction represents a document.replaceDraft action (deprecated).
+type DocumentReplaceDraftAction struct {
+	ActionType  string           `json:"actionType"`
+	PublishedID string           `json:"publishedId"`
+	Purge       bool             `json:"purge,omitempty"`
+	Attributes  *json.RawMessage `json:"attributes"`
+}
+
+// DocumentVersionCreateAction represents a document.version.create action.
+type DocumentVersionCreateAction struct {
+	ActionType       string           `json:"actionType"`
+	PublishedID      string           `json:"publishedId"`
+	Document         *json.RawMessage `json:"document,omitempty"`
+	VersionID        string           `json:"versionId,omitempty"`
+	BaseID           string           `json:"baseId,omitempty"`
+	IfBaseRevisionID string           `json:"ifBaseRevisionId,omitempty"`
+}
+
+// DocumentVersionDiscardAction represents a document.version.discard action.
+type DocumentVersionDiscardAction struct {
+	ActionType string `json:"actionType"`
+	VersionID  string `json:"versionId"`
+	Purge      bool   `json:"purge,omitempty"`
+}
+
+// DocumentVersionReplaceAction represents a document.version.replace action.
+type DocumentVersionReplaceAction struct {
+	ActionType string           `json:"actionType"`
+	VersionID  string           `json:"versionId"`
+	Attributes *json.RawMessage `json:"attributes"`
+	Purge      bool             `json:"purge,omitempty"`
+}
+
+// DocumentVersionUnpublishAction represents a document.version.unpublish action.
+type DocumentVersionUnpublishAction struct {
+	ActionType string `json:"actionType"`
+	VersionID  string `json:"versionId"`
+}
+
+// ReleaseMetadata contains release metadata fields.
+type ReleaseMetadata struct {
+	Title             string `json:"title,omitempty"`
+	Description       string `json:"description,omitempty"`
+	ReleaseType       string `json:"releaseType,omitempty"`
+	IntendedPublishAt string `json:"intendedPublishAt,omitempty"`
+}
+
+// ReleaseCreateAction represents a release.create action.
+type ReleaseCreateAction struct {
+	ActionType string           `json:"actionType"`
+	ReleaseID  string           `json:"releaseId"`
+	Metadata   *ReleaseMetadata `json:"metadata,omitempty"`
+}
+
+// ReleaseEditAction represents a release.edit action.
+type ReleaseEditAction struct {
+	ActionType string           `json:"actionType"`
+	ReleaseID  string           `json:"releaseId"`
+	Metadata   *ReleaseMetadata `json:"metadata,omitempty"`
+}
+
+// ReleaseDeleteAction represents a release.delete action.
+type ReleaseDeleteAction struct {
+	ActionType string `json:"actionType"`
+	ReleaseID  string `json:"releaseId"`
+	Purge      bool   `json:"purge,omitempty"`
+}
+
+// ReleasePublishAction represents a release.publish action.
+type ReleasePublishAction struct {
+	ActionType string `json:"actionType"`
+	ReleaseID  string `json:"releaseId"`
+}
+
+// ReleaseScheduleAction represents a release.schedule action.
+type ReleaseScheduleAction struct {
+	ActionType string `json:"actionType"`
+	ReleaseID  string `json:"releaseId"`
+	PublishAt  string `json:"publishAt"`
+}
+
+// ReleaseArchiveAction represents a release.archive action.
+type ReleaseArchiveAction struct {
+	ActionType string `json:"actionType"`
+	ReleaseID  string `json:"releaseId"`
+}
+
+// ReleaseUnarchiveAction represents a release.unarchive action.
+type ReleaseUnarchiveAction struct {
+	ActionType string `json:"actionType"`
+	ReleaseID  string `json:"releaseId"`
+}
+
+// ReleaseUnscheduleAction represents a release.unschedule action.
+type ReleaseUnscheduleAction struct {
+	ActionType string `json:"actionType"`
+	ReleaseID  string `json:"releaseId"`
+}


### PR DESCRIPTION
## Summary
- add Actions builder to support Sanity Actions API
- handle actions request/response types
- test Actions API integration
- add dedicated structs for each Actions API operation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_686876cc48dc8330852a790e78706c98